### PR TITLE
Recalculate timline bounding box on every mouse enter

### DIFF
--- a/packages/plugins/MagicPlayer/src/components/MagicPlayerTimeline.vue
+++ b/packages/plugins/MagicPlayer/src/components/MagicPlayerTimeline.vue
@@ -34,7 +34,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, inject, onMounted } from 'vue'
+import { ref, computed, watch, inject } from 'vue'
 import { MediaApiInjectionKey, PlayerApiInjectionKey } from './../types'
 import { useResizeObserver, useEventListener } from '@vueuse/core'
 import { clampValue, mapValue } from './../utils'
@@ -73,6 +73,7 @@ watch(currentTime, (value) => {
 })
 
 const onMouseEnter = () => {
+  getTimelineTrackSize()
   entered.value = true
 }
 
@@ -128,10 +129,6 @@ const getTimelineTrackSize = () => {
 useResizeObserver(trackRef, getTimelineTrackSize)
 useEventListener(defaultWindow, 'resize', getTimelineTrackSize, {
   passive: true,
-})
-
-onMounted(() => {
-  getTimelineTrackSize()
 })
 </script>
 


### PR DESCRIPTION
This fixes bugs that happens when the player position is changed after mount (for example by a translateX).