### PR TITLE
Timeline Preview on hover for Mux Videos

### DIFF
--- a/packages/plugins/MagicPlayer/demo.vue
+++ b/packages/plugins/MagicPlayer/demo.vue
@@ -9,16 +9,6 @@
     </magic-player>
   </div>
 
-  <p>File [mp4]</p>
-  <div class="w-full aspect-[16/9]">
-    <magic-player
-      provider="file"
-      src="https://stream.mux.com/c2sidhKoTaKUTgqqACU8AsRRq02uUbEFLrgGQXDjlJks/high.mp4"
-    >
-      <magic-player-controls />
-    </magic-player>
-  </div>
-
   <p>Hls [m3u8]</p>
   <div class="w-full aspect-[16/9]">
     <magic-player
@@ -29,7 +19,7 @@
     </magic-player>
   </div>
 
-  <p>Muxt Timeline Preview</p>
+  <p>Mux Timeline Preview</p>
   <div class="w-full aspect-[16/9]">
     <magic-player
       provider="file"

--- a/packages/plugins/MagicPlayer/demo.vue
+++ b/packages/plugins/MagicPlayer/demo.vue
@@ -9,6 +9,16 @@
     </magic-player>
   </div>
 
+  <p>File [mp4]</p>
+  <div class="w-full aspect-[16/9]">
+    <magic-player
+      provider="file"
+      src="https://stream.mux.com/c2sidhKoTaKUTgqqACU8AsRRq02uUbEFLrgGQXDjlJks/high.mp4"
+    >
+      <magic-player-controls />
+    </magic-player>
+  </div>
+
   <p>Hls [m3u8]</p>
   <div class="w-full aspect-[16/9]">
     <magic-player
@@ -16,6 +26,25 @@
       src="https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8"
     >
       <magic-player-controls />
+    </magic-player>
+  </div>
+
+  <p>Muxt Timeline Preview</p>
+  <div class="w-full aspect-[16/9]">
+    <magic-player
+      provider="file"
+      src="https://stream.mux.com/c2sidhKoTaKUTgqqACU8AsRRq02uUbEFLrgGQXDjlJks/high.mp4"
+    >
+      <magic-player-controls>
+        <template #seekPopover="{ seekedTime, touched }">
+          <magic-player-mux-timeline-preview
+            v-if="touched"
+            playbackId="c2sidhKoTaKUTgqqACU8AsRRq02uUbEFLrgGQXDjlJks"
+            :time="seekedTime"
+            class="mb-[1rem] w-[10rem] rounded-[4px] overflow-hidden"
+          />
+        </template>
+      </magic-player-controls>
     </magic-player>
   </div>
 </template>

--- a/packages/plugins/MagicPlayer/index.md
+++ b/packages/plugins/MagicPlayer/index.md
@@ -36,3 +36,29 @@ A magic plugin that adds a player to the page.
   import { MagicPlayer, MagicPlayerControls } from '@maas/vue-equipment;
 </script>
 ```
+
+### Mux Timeline Preview
+
+```html
+<template>
+  <magic-player
+    provider="file"
+    src="https://stream.mux.com/c2sidhKoTaKUTgqqACU8AsRRq02uUbEFLrgGQXDjlJks/high.mp4"
+  >
+    <magic-player-controls>
+      <template #seekPopover="{ seekedTime, touched }">
+        <magic-player-mux-timeline-preview
+          v-if="touched"
+          playbackId="c2sidhKoTaKUTgqqACU8AsRRq02uUbEFLrgGQXDjlJks"
+          :time="seekedTime"
+          class="mb-[1rem] w-[10rem] rounded-[4px] overflow-hidden"
+        />
+      </template>
+    </magic-player-controls>
+  </magic-player>
+</template>
+
+<script setup>
+  import { MagicPlayer, MagicPlayerControls, MagicPlayerMuxTimelinePreview } from '@maas/vue-equipment;
+</script>
+```

--- a/packages/plugins/MagicPlayer/index.ts
+++ b/packages/plugins/MagicPlayer/index.ts
@@ -3,6 +3,7 @@ import type { App, Plugin } from 'vue'
 import MagicPlayerComponent from './src/components/MagicPlayer.vue'
 import MagicPlayerControlsComponent from './src/components/MagicPlayerControls.vue'
 import MagicPlayerTimelineComponent from './src/components/MagicPlayerTimeline.vue'
+import MagicPlayerMuxTimelinePreviewComponent from './src/components/MagicPlayerMuxTimelinePreview.vue'
 
 import { useMediaApi } from './src/composables/useMediaApi'
 import { usePlayerApi } from './src/composables/usePlayerApi'
@@ -14,7 +15,11 @@ const MagicPlayer: Plugin = {
   install: (app: App) => {
     app.component('MagicPlayer', MagicPlayerComponent)
     app.component('MagicPlayerControls', MagicPlayerControlsComponent)
-    app.component('MagicPlayerTimeline', MagicPlayerTimelineComponent)
+    app.component('MagicPlayerTimeline', MagicPlayerTimelineComponent),
+      app.component(
+        'MagicPlayerMuxTimelinePreview',
+        MagicPlayerMuxTimelinePreviewComponent
+      )
   },
 }
 

--- a/packages/plugins/MagicPlayer/src/components/MagicPlayerControls.vue
+++ b/packages/plugins/MagicPlayer/src/components/MagicPlayerControls.vue
@@ -41,7 +41,11 @@
         </button>
       </div>
       <div class="magic-player-controls__item -grow">
-        <magic-player-timeline />
+        <magic-player-timeline>
+          <template #seekPopover="{ seekedTime }" v-if="$slots.seekPopover">
+            <slot name="seekPopover" :seeked-time="seekedTime" :touched="touched" />
+          </template>
+        </magic-player-timeline>
       </div>
       <div class="magic-player-controls__item -shrink-0">
         <button v-if="muted" @click="unmute">

--- a/packages/plugins/MagicPlayer/src/components/MagicPlayerMuxTimelinePreview.vue
+++ b/packages/plugins/MagicPlayer/src/components/MagicPlayerMuxTimelinePreview.vue
@@ -1,0 +1,91 @@
+<template>
+  <canvas
+    ref="canvas"
+    :width="storyboard?.tile_width"
+    :height="storyboard?.tile_height"
+  />
+</template>
+<script setup lang="ts">
+import { shallowRef, onMounted, watch } from 'vue'
+import type { Ref } from 'vue'
+
+type Props = {
+  time: number
+  playbackId: string
+}
+
+type MuxStoryboard = {
+  url: string
+  tile_width: number
+  tile_height: number
+  duration: number
+  tiles: Array<{
+    start: number
+    x: number
+    y: number
+  }>
+}
+
+const props = defineProps<Props>()
+const canvas = shallowRef() as Ref<HTMLCanvasElement>
+let context: CanvasRenderingContext2D | undefined = undefined
+const storyboard = shallowRef<MuxStoryboard | undefined>()
+let image: HTMLImageElement | undefined = undefined
+
+async function init() {
+  if (!props.playbackId) return
+
+  try {
+    storyboard.value = await fetch(
+      `https://image.mux.com/${props.playbackId}/storyboard.json`
+    ).then((res) => res.json())
+
+    if (!storyboard.value) throw new Error()
+
+    image = new Image()
+    image.src = storyboard.value.url
+    await image.decode()
+
+    context = canvas.value.getContext('2d')!
+    context.drawImage(image, 0, 0)
+  } catch (e: any) {
+    console.error('Can not initialize timeine preview.', e)
+  }
+}
+
+function drawFrame(time: number) {
+  if (!storyboard.value || !context || !image) return
+
+  const { tile_height, tile_width, tiles } = storyboard.value
+
+  let closestIndex = -1
+  let minDifference = Infinity
+
+  for (let i = 0; i < tiles.length; i++) {
+    const { start } = tiles[i]
+    const difference = Math.abs(start - time)
+
+    if (difference < minDifference) {
+      minDifference = difference
+      closestIndex = i
+    }
+  }
+
+  const tile = tiles[closestIndex]
+
+  context.drawImage(
+    image,
+    tile.x,
+    tile.y,
+    tile_width,
+    tile_height,
+    0,
+    0,
+    tile_width,
+    tile_height
+  )
+}
+
+onMounted(init)
+watch(() => props.time, drawFrame)
+</script>

--- a/packages/plugins/MagicPlayer/src/components/MagicPlayerTimeline.vue
+++ b/packages/plugins/MagicPlayer/src/components/MagicPlayerTimeline.vue
@@ -7,6 +7,13 @@
     @pointerup="onPointerUp"
     @pointermove="onPointerMove"
   >
+    <div
+      v-show="!!seekedTime"
+      class="magic-player-timeline__seek-popover"
+      :style="{ left: `${seekedPercentage}%` }"
+    >
+      <slot name="seekPopover" :seeked-time="seekedTime" />
+    </div>
     <div ref="trackRef" class="magic-player-timeline__slider-track">
       <div
         class="magic-player-timeline__slider-thumb"
@@ -43,7 +50,7 @@ import { defaultWindow } from '@vueuse/core'
 const { duration, currentTime, playing, buffered } =
   inject(MediaApiInjectionKey)!
 
-const { play, pause, seek } = inject(PlayerApiInjectionKey)!
+const { play, pause, seek, touched } = inject(PlayerApiInjectionKey)!
 
 const trackRef = ref<HTMLDivElement | undefined>(undefined)
 const trackRect = ref<DOMRect | undefined>(undefined)
@@ -191,7 +198,6 @@ onMounted(() => {
   background-color: var(--magic-player-thumb-bg-color);
   border-radius: 50rem;
 }
-
 .magic-player-timeline__slider-scrubbed,
 .magic-player-timeline__slider-seeked,
 .magic-player-timeline__slider-buffered {
@@ -220,5 +226,12 @@ onMounted(() => {
 
 .magic-player-timeline:hover .magic-player-timeline__slider-thumb-handle {
   transform: translate(-50%, -50%) scale(1);
+}
+
+.magic-player-timeline__seek-popover {
+  position: absolute;
+  left: 0;
+  bottom: 100%;
+  transform: translateX(-50%);
 }
 </style>


### PR DESCRIPTION
Added a Mux specific component that draws a video frame to a canvas based on a playbackId and a time. Added slots to the current components to optinally pass this new component to the timeline component.