### PR TITLE
fix(build): exclude package.json from build pattern

### DIFF
--- a/packages/plugins/scripts/build.ts
+++ b/packages/plugins/scripts/build.ts
@@ -25,6 +25,7 @@ mkdist({
     '!index.md',
     '!node_modules',
     '!package.json',
+    '!**/package.json',
     '!pnpm-lock.yaml',
     '!shims-vue.d.ts',
     '!tsconfig.json',


### PR DESCRIPTION
### Description

The `mkdist` build for `packages/plugins` only excluded the top-level `package.json` (`!package.json`), so any nested `package.json` inside a plugin folder gets copied as-is into `dist/plugins/<plugin>/package.json`.

The Nuxt module aliases `@maas/vue-equipment/plugins` directly to `dist/plugins`, bypassing the root package's `exports` map. When resolving a plugin subpath through that alias, the bundler resolves the target directory and, if it finds a nested `package.json` there, follows its `main`/`exports` fields instead of the plugin's actual built entry — which breaks for any plugin whose leftover `package.json` points somewhere that doesn't exist in the published output.

This is currently reproducible via `MagicError` (a leftover from when it was a standalone `tsup`-built package), and surfaced after upgrading to Nuxt 4.5.0 (Vite `7 → 8`), whose resolver started honoring nested `package.json` files when resolving an aliased directory:
`
Cannot find module '.../dist/plugins/MagicError/dist/index.js' imported from '.../dist/plugins/MagicDrawer/src/components/MagicDrawerTrigger.vue'
`

Fix: exclude nested `package.json` files (`'!**/package.json'`) from the `mkdist` pattern in `packages/plugins/scripts/build.ts`, so no plugin can ship one that shadows the package's own resolution.

Fixes #429 

Verified by rebuilding `plugins` and swapping the built `dist/plugins` into a Nuxt 4.5.1 consumer project that was reproducing the error — the import resolves correctly and the app renders as expected.
